### PR TITLE
Fix slider links to use correct product ID

### DIFF
--- a/src/components/slider.php
+++ b/src/components/slider.php
@@ -17,7 +17,7 @@ $sliders = $slider->fetchAll(PDO::FETCH_ASSOC);
                     <div class="product-info">
                         <p class="product-title"><?= $slidern["nombre"]; ?></p>
                         <p class="product-description"><?= $slidern["descripcion"]; ?></p>
-                        <a href="/producto/<?= preg_replace('/[^a-zA-Z0-9]/', '-', strtolower($slidern["nombre"])); ?>?id=<?= $producto["id"]; ?>" class="btn">Ver producto</a>
+                        <a href="/producto/<?= preg_replace('/[^a-zA-Z0-9]/', '-', strtolower($slidern["nombre"])); ?>?id=<?= $slidern["id"]; ?>" class="btn">Ver producto</a>
                     </div>
                     <div class="product-image box-img">
                         <img src="<?php if (is_array($slidern["imagen"])) echo $slidern["imagen"][0];


### PR DESCRIPTION
## Summary
- fix slider links so slides point to the correct product

## Testing
- `php -l src/components/slider.php`


------
https://chatgpt.com/codex/tasks/task_b_687d4695b83c8333a05e268e4236d670