### PR TITLE
Fix date grouping in chart data queries

### DIFF
--- a/src/scripts/chart_data.php
+++ b/src/scripts/chart_data.php
@@ -27,10 +27,10 @@ if ($_SERVER["REQUEST_METHOD"] === "GET") {
 
         // Obtener los últimos 7 días agrupados por día
         $stmtv7 = $pdo->prepare("
-            SELECT DATE(visit_date) as fecha, COUNT(*) as total 
-            FROM visitas 
-            WHERE visit_date >= NOW() - INTERVAL 7 DAY 
-            GROUP BY DATE(fecha) 
+            SELECT DATE(visit_date) as fecha, COUNT(*) as total
+            FROM visitas
+            WHERE visit_date >= NOW() - INTERVAL 7 DAY
+            GROUP BY DATE(visit_date)
             ORDER BY fecha ASC
         ");
         $stmtv7->execute();
@@ -38,10 +38,10 @@ if ($_SERVER["REQUEST_METHOD"] === "GET") {
 
         // Obtener los últimos 14 días antes de los últimos 7 días agrupados por día
         $stmtv14 = $pdo->prepare("
-            SELECT DATE(visit_date) as fecha, COUNT(*) as total 
-            FROM visitas 
-            WHERE visit_date >= NOW() - INTERVAL 14 DAY AND visit_date < NOW() - INTERVAL 7 DAY 
-            GROUP BY DATE(fecha) 
+            SELECT DATE(visit_date) as fecha, COUNT(*) as total
+            FROM visitas
+            WHERE visit_date >= NOW() - INTERVAL 14 DAY AND visit_date < NOW() - INTERVAL 7 DAY
+            GROUP BY DATE(visit_date)
             ORDER BY fecha ASC
         ");
         $stmtv14->execute();


### PR DESCRIPTION
## Summary
- correct grouping in visits chart queries to use `DATE(visit_date)`

## Testing
- `php -l src/scripts/chart_data.php`

------
https://chatgpt.com/codex/tasks/task_b_687d4925266c833380abd03a74d7db30