### PR TITLE
Add JSON headers

### DIFF
--- a/src/api/attributes/add_attribute.php
+++ b/src/api/attributes/add_attribute.php
@@ -1,4 +1,5 @@
 <?php
+header('Content-Type: application/json');
 require '../../scripts/conn.php'; // Conexión a la base de datos
 
 // Verifica si la solicitud es POST

--- a/src/api/attributes/all_views_attribute.php
+++ b/src/api/attributes/all_views_attribute.php
@@ -1,4 +1,5 @@
 <?php
+header('Content-Type: application/json');
 require '../../scripts/conn.php'; // Conexión a la base de datos
 
 // Verifica si la solicitud es GET

--- a/src/api/attributes/delete_attribute.php
+++ b/src/api/attributes/delete_attribute.php
@@ -1,4 +1,5 @@
 <?php
+header('Content-Type: application/json');
 require '../../scripts/conn.php'; // Conexión a la base de datos
 
 // Verifica si la solicitud es POST

--- a/src/api/attributes/edit_attribute.php
+++ b/src/api/attributes/edit_attribute.php
@@ -1,4 +1,5 @@
 <?php
+header('Content-Type: application/json');
 require '../../scripts/conn.php'; // Conexión a la base de datos
 
 // Verifica si la solicitud es POST

--- a/src/api/attributes/read_attributes.php
+++ b/src/api/attributes/read_attributes.php
@@ -1,4 +1,5 @@
 <?php
+header('Content-Type: application/json');
 require '../../scripts/conn.php'; // Conexión a la base de datos
 
 // Verifica si la solicitud es POST

--- a/src/api/categories/add_category.php
+++ b/src/api/categories/add_category.php
@@ -1,4 +1,5 @@
 <?php
+header('Content-Type: application/json');
 require '../../scripts/conn.php'; // Conexión a la base de datos
 
 // Verifica si la solicitud es POST

--- a/src/api/categories/all_views_category.php
+++ b/src/api/categories/all_views_category.php
@@ -1,4 +1,5 @@
 <?php
+header('Content-Type: application/json');
 require '../../scripts/conn.php'; // Conexión a la base de datos
 
 // Verifica si la solicitud es GET

--- a/src/api/categories/delete_category.php
+++ b/src/api/categories/delete_category.php
@@ -1,4 +1,5 @@
 <?php
+header('Content-Type: application/json');
 require '../../scripts/conn.php'; // Conexión a la base de datos
 
 // Verifica si la solicitud es POST

--- a/src/api/categories/edit_category.php
+++ b/src/api/categories/edit_category.php
@@ -1,4 +1,5 @@
 <?php
+header('Content-Type: application/json');
 require '../../scripts/conn.php'; // Conexión a la base de datos
 
 // Verifica si la solicitud es POST

--- a/src/api/categories/read_all_categories.php
+++ b/src/api/categories/read_all_categories.php
@@ -1,4 +1,5 @@
 <?php
+header('Content-Type: application/json');
 require '../../scripts/conn.php'; // Conexión a la base de datos
 
 // Verifica si la solicitud es GET

--- a/src/api/categories/read_categories.php
+++ b/src/api/categories/read_categories.php
@@ -1,4 +1,5 @@
 <?php
+header('Content-Type: application/json');
 require '../../scripts/conn.php'; // Conexión a la base de datos
 
 // Verifica si la solicitud es POST

--- a/src/api/products/all_views_product.php
+++ b/src/api/products/all_views_product.php
@@ -1,4 +1,5 @@
 <?php
+header('Content-Type: application/json');
 require '../../scripts/conn.php'; // Conexión a la base de datos
 
 // Verifica si la solicitud es GET

--- a/src/api/products/delete_product.php
+++ b/src/api/products/delete_product.php
@@ -1,4 +1,5 @@
 <?php
+header('Content-Type: application/json');
 require '../../scripts/conn.php'; // Conexión a la base de datos
 
 // Verifica si la solicitud es POST

--- a/src/api/products/edit_product.php
+++ b/src/api/products/edit_product.php
@@ -1,4 +1,5 @@
 <?php
+header('Content-Type: application/json');
 require '../../scripts/conn.php'; // Conexión a la base de datos
 
 // Verifica si la solicitud es POST

--- a/src/api/products/id_product.php
+++ b/src/api/products/id_product.php
@@ -1,4 +1,5 @@
 <?php
+header('Content-Type: application/json');
 require '../../scripts/conn.php'; // Conexión a la base de datos
 
 // Verifica si la solicitud es GET

--- a/src/api/products/read_by_name.php
+++ b/src/api/products/read_by_name.php
@@ -1,4 +1,5 @@
 <?php
+header('Content-Type: application/json');
 require '../../scripts/conn.php'; // Conexión a la base de datos
 
 // Verifica si la solicitud es GET

--- a/src/api/products/read_products.php
+++ b/src/api/products/read_products.php
@@ -1,4 +1,5 @@
 <?php
+header('Content-Type: application/json');
 require '../../scripts/conn.php'; // Conexión a la base de datos
 
 // Verifica si la solicitud es GET

--- a/src/api/subcategories/add_subcategory.php
+++ b/src/api/subcategories/add_subcategory.php
@@ -1,4 +1,5 @@
 <?php
+header('Content-Type: application/json');
 require '../../scripts/conn.php'; // Conexión a la base de datos
 
 // Verifica si la solicitud es POST

--- a/src/api/subcategories/all_views_subcategory.php
+++ b/src/api/subcategories/all_views_subcategory.php
@@ -1,4 +1,5 @@
 <?php
+header('Content-Type: application/json');
 require '../../scripts/conn.php'; // Conexión a la base de datos
 
 // Verifica si la solicitud es GET

--- a/src/api/subcategories/delete_subcategory.php
+++ b/src/api/subcategories/delete_subcategory.php
@@ -1,4 +1,5 @@
 <?php
+header('Content-Type: application/json');
 require '../../scripts/conn.php'; // Conexión a la base de datos
 
 // Verifica si la solicitud es POST

--- a/src/api/subcategories/edit_subcategory.php
+++ b/src/api/subcategories/edit_subcategory.php
@@ -1,4 +1,5 @@
 <?php
+header('Content-Type: application/json');
 require '../../scripts/conn.php'; // Conexión a la base de datos
 
 // Verifica si la solicitud es POST

--- a/src/api/subcategories/read_subcategories.php
+++ b/src/api/subcategories/read_subcategories.php
@@ -1,4 +1,5 @@
 <?php
+header('Content-Type: application/json');
 require '../../scripts/conn.php'; // Conexión a la base de datos
 
 // Verifica si la solicitud es POST

--- a/src/api/subcategories/read_subcategories_specific.php
+++ b/src/api/subcategories/read_subcategories_specific.php
@@ -1,4 +1,5 @@
 <?php
+header('Content-Type: application/json');
 require '../../scripts/conn.php'; // Conexión a la base de datos
 
 // Verifica si la solicitud es POST

--- a/src/api/users/add_user.php
+++ b/src/api/users/add_user.php
@@ -1,4 +1,5 @@
 <?php
+header('Content-Type: application/json');
 require '../../scripts/conn.php'; // Conexión a la base de datos
 
 // Verifica si la solicitud es POST

--- a/src/api/users/all_views_user.php
+++ b/src/api/users/all_views_user.php
@@ -1,4 +1,5 @@
 <?php
+header('Content-Type: application/json');
 require '../../scripts/conn.php'; // Conexión a la base de datos
 
 // Verifica si la solicitud es GET

--- a/src/api/users/delete_user.php
+++ b/src/api/users/delete_user.php
@@ -1,4 +1,5 @@
 <?php
+header('Content-Type: application/json');
 require '../../scripts/conn.php'; // Conexión a la base de datos
 
 // Verifica si la solicitud es POST

--- a/src/api/users/edit_user.php
+++ b/src/api/users/edit_user.php
@@ -1,4 +1,5 @@
 <?php
+header('Content-Type: application/json');
 require '../../scripts/conn.php'; // Conexión a la base de datos
 
 // Verifica si la solicitud es POST

--- a/src/api/users/read_users.php
+++ b/src/api/users/read_users.php
@@ -1,4 +1,5 @@
 <?php
+header('Content-Type: application/json');
 require '../../scripts/conn.php'; // Conexión a la base de datos
 
 // Verifica si la solicitud es POST

--- a/src/api/users/verify_user.php
+++ b/src/api/users/verify_user.php
@@ -1,4 +1,5 @@
 <?php
+header('Content-Type: application/json');
 session_start();
 require '../../scripts/conn.php'; // Conexión a la base de datos
 

--- a/src/scripts/ad_logic.php
+++ b/src/scripts/ad_logic.php
@@ -1,4 +1,5 @@
 <?php
+header('Content-Type: application/json');
 if ($_SERVER["REQUEST_METHOD"] === "POST") {
 
     if (isset($_FILES['image']) && !empty($_FILES['image']['name'][0])) {

--- a/src/scripts/ad_visit.php
+++ b/src/scripts/ad_visit.php
@@ -1,4 +1,5 @@
 <?php
+header('Content-Type: application/json');
 if ($_SERVER["REQUEST_METHOD"] === "GET") {
     require("conn.php");
     $id = $_GET["id"];

--- a/src/scripts/add_order.php
+++ b/src/scripts/add_order.php
@@ -1,4 +1,5 @@
 <?php
+header('Content-Type: application/json');
 if ($_SERVER["REQUEST_METHOD"] === "POST") {
     require("conn.php");
     $producto_ids = $_POST["id"] ?? [];

--- a/src/scripts/chart_data.php
+++ b/src/scripts/chart_data.php
@@ -1,4 +1,5 @@
 <?php
+header('Content-Type: application/json');
 if ($_SERVER["REQUEST_METHOD"] === "GET") {
     require("conn.php");
 

--- a/src/scripts/imgOpt.php
+++ b/src/scripts/imgOpt.php
@@ -1,4 +1,5 @@
 <?php
+header('Content-Type: application/json');
 // Directorio de destino
 $destino = __DIR__ . '/../../public/img/';
 

--- a/src/scripts/onUser.php
+++ b/src/scripts/onUser.php
@@ -1,4 +1,5 @@
 <?php
+header('Content-Type: application/json');
 session_start();
 require "conn.php";
 try {


### PR DESCRIPTION
## Summary
- add `Content-Type: application/json` header to API endpoints and JSON scripts

## Testing
- `php -l` on all modified PHP files

------
https://chatgpt.com/codex/tasks/task_b_687d49f204b88333bece6c616b8b745f