### PR TITLE
Add CSRF tokens to admin pages

### DIFF
--- a/routes/suadview/categories_edit.php
+++ b/routes/suadview/categories_edit.php
@@ -16,6 +16,8 @@ if ($privilegios !== 'administrador' && $privilegios !== 'vendedor' && $privileg
 }
 
 require '../../src/scripts/conn.php'; // Conexión a la base de datos
+require '../../src/scripts/csrf.php';
+$csrf_token = generate_csrf_token();
 
 $id = $_GET['id'];
 
@@ -523,6 +525,7 @@ if (!empty($id)) {
                             <div class="col-md-10 col-lg-8">
                                 <form id="category" method="POST" data-action="<?php if (!empty($id)) echo "edit";
                                                                                 else echo "add"; ?>" onsubmit="return false;">
+                                    <input type="hidden" id="csrf_token" value="<?php echo htmlspecialchars($csrf_token); ?>">
                                     <div class="mb-4">
                                         <label class="form-label" for="dm-ecom-product-name">Nombre</label>
                                         <input type="text" class="form-control" id="dm-ecom-product-name" name="dm-ecom-product-name"
@@ -603,13 +606,16 @@ if (!empty($id)) {
                 "/src/api/categories/edit_category.php" :
                 "/src/api/categories/add_category.php";
 
+            const csrfToken = document.getElementById("csrf_token").value;
             const body = action === "edit" ? JSON.stringify({
                 nombre,
                 id,
-                destacado
+                destacado,
+                csrf_token: csrfToken
             }) : JSON.stringify({
                 nombre,
-                destacado
+                destacado,
+                csrf_token: csrfToken
             });
 
             try {

--- a/routes/suadview/login.php
+++ b/routes/suadview/login.php
@@ -6,6 +6,11 @@ $_SESSION = array();
 
 // Finally, destroy the session
 session_destroy();
+
+// Start a fresh session to handle CSRF tokens
+session_start();
+require_once __DIR__ . '/../../src/scripts/csrf.php';
+$csrf_token = generate_csrf_token();
 ?>
 
 <!doctype html>
@@ -122,6 +127,7 @@ session_destroy();
                             <div class="row g-0 justify-content-center">
                                 <div class="col-sm-8 col-xl-6">
                                     <form class="js-validation-signin" method="POST">
+                                        <input type="hidden" id="csrf_token" name="csrf_token" value="<?php echo htmlspecialchars($csrf_token); ?>">
                                         <div class="py-3">
                                             <div class="mb-4">
                                                 <input type="text" class="form-control form-control-lg form-control-alt" id="login-username" name="login-username" placeholder="Usuario">
@@ -181,6 +187,7 @@ session_destroy();
                 let formData = new FormData();
                 formData.append("user", user.value);
                 formData.append("pass", pass.value);
+                formData.append("csrf_token", document.getElementById("csrf_token").value);
 
                 try {
                     let response = await fetch("/src/api/users/verify_user.php", {

--- a/src/api/categories/add_category.php
+++ b/src/api/categories/add_category.php
@@ -1,6 +1,8 @@
 <?php
 header('Content-Type: application/json');
+session_start();
 require '../../scripts/conn.php'; // Conexión a la base de datos
+require '../../scripts/csrf.php';
 
 // Verifica si la solicitud es POST
 if ($_SERVER["REQUEST_METHOD"] === "POST") {
@@ -8,6 +10,12 @@ if ($_SERVER["REQUEST_METHOD"] === "POST") {
     $data = json_decode(file_get_contents("php://input"), true);
     $nombre = trim($data["nombre"] ?? "");
     $destacado = trim($data["destacado"] ?? "");
+    $token = $data["csrf_token"] ?? "";
+
+    if (!validate_csrf_token($token)) {
+        echo json_encode(["status" => "error", "message" => "Token CSRF inválido."]);
+        exit;
+    }
 
     // Validación básica
     if (empty($nombre)) {

--- a/src/api/categories/edit_category.php
+++ b/src/api/categories/edit_category.php
@@ -1,6 +1,8 @@
 <?php
 header('Content-Type: application/json');
+session_start();
 require '../../scripts/conn.php'; // Conexión a la base de datos
+require '../../scripts/csrf.php';
 
 // Verifica si la solicitud es POST
 if ($_SERVER["REQUEST_METHOD"] === "POST") {
@@ -9,6 +11,12 @@ if ($_SERVER["REQUEST_METHOD"] === "POST") {
     $nombre = trim($data["nombre"] ?? "");
     $id = trim($data["id"] ?? "");
     $destacado = trim($data["destacado"] ?? "");
+    $token = $data["csrf_token"] ?? "";
+
+    if (!validate_csrf_token($token)) {
+        echo json_encode(["status" => "error", "message" => "Token CSRF inválido."]);
+        exit;
+    }
 
     // Validación básica
     if (empty($nombre)) {

--- a/src/api/users/verify_user.php
+++ b/src/api/users/verify_user.php
@@ -2,12 +2,19 @@
 header('Content-Type: application/json');
 session_start();
 require '../../scripts/conn.php'; // Conexión a la base de datos
+require '../../scripts/csrf.php';
 
 // Verifica si la solicitud es POST
 if ($_SERVER["REQUEST_METHOD"] === "POST") {
     // Obtiene y limpia los datos enviados
     $user = trim($_POST["user"] ?? "");
     $pass = trim($_POST["pass"] ?? "");
+    $token = $_POST["csrf_token"] ?? "";
+
+    if (!validate_csrf_token($token)) {
+        echo json_encode(["status" => "error", "message" => "Token CSRF inválido."]);
+        exit;
+    }
 
     // Validación básica
     if (empty($user) || empty($pass)) {

--- a/src/scripts/csrf.php
+++ b/src/scripts/csrf.php
@@ -1,0 +1,19 @@
+<?php
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+function generate_csrf_token() {
+    if (empty($_SESSION['csrf_token'])) {
+        $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+    }
+    return $_SESSION['csrf_token'];
+}
+
+function validate_csrf_token($token) {
+    if (!isset($_SESSION['csrf_token']) || !$token) {
+        return false;
+    }
+    return hash_equals($_SESSION['csrf_token'], $token);
+}
+?>


### PR DESCRIPTION
## Summary
- generate CSRF tokens in a helper
- add CSRF protection to the admin login page
- enforce CSRF validation in login verification API
- embed CSRF tokens in category edit page and related APIs

## Testing
- `php -l src/scripts/csrf.php`
- `php -l routes/suadview/login.php`
- `php -l routes/suadview/categories_edit.php`
- `php -l src/api/users/verify_user.php`
- `php -l src/api/categories/add_category.php`
- `php -l src/api/categories/edit_category.php`


------
https://chatgpt.com/codex/tasks/task_b_687d4b55ca988333a0680474b6d727ad