### PR TITLE
Implement CSRF token on product edit

### DIFF
--- a/routes/suadview/products_edit.php
+++ b/routes/suadview/products_edit.php
@@ -16,6 +16,8 @@ if ($privilegios !== 'administrador' && $privilegios !== 'vendedor' && $privileg
 }
 
 require '../../src/scripts/conn.php'; // Conexión a la base de datos
+require '../../src/scripts/csrf.php';
+$csrf_token = generate_csrf_token();
 
 $id = $_GET['id'];
 
@@ -533,6 +535,7 @@ if (!empty($id)) {
                             <div class="col-md-10 col-lg-8">
                                 <form action="be_pages_ecom_product_edit.html" method="POST" data-action="<?php if (!empty($id)) echo "edit";
                                                                                                             else echo "add"; ?>" onsubmit="return false;">
+                                    <input type="hidden" id="csrf_token" value="<?php echo htmlspecialchars($csrf_token); ?>">
                                     <div class="mb-4">
                                         <label class="form-label" for="dm-ecom-product-id">Código</label>
                                         <input type="text" class="form-control" id="dm-ecom-product-id" name="dm-ecom-product-id"
@@ -799,6 +802,8 @@ if (!empty($id)) {
                         formData.append("image[]", file);
                     });
                 }
+
+                formData.append("csrf_token", document.getElementById("csrf_token").value);
 
                 // Verifica si es una edición o una adición
                 let apiUrl = formAction === "edit" ? "/src/api/products/edit_product.php" : "/src/api/products/add_product.php";


### PR DESCRIPTION
## Summary
- generate CSRF token in `products_edit.php`
- embed token as hidden form field
- pass token in AJAX form submission

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_687d53a567d88333b8c550a6dee15298