### PR TITLE
Implement CSRF checks for product API actions

### DIFF
--- a/src/api/products/add_product.php
+++ b/src/api/products/add_product.php
@@ -1,5 +1,8 @@
 <?php
+header('Content-Type: application/json');
+session_start();
 require '../../scripts/conn.php'; // Conexión a la base de datos
+require '../../scripts/csrf.php';
 
 // Verifica si la solicitud es POST
 if ($_SERVER["REQUEST_METHOD"] === "POST") {
@@ -54,6 +57,12 @@ if ($_SERVER["REQUEST_METHOD"] === "POST") {
     $precioD = trim($_POST["precioD"] ?? 0);
     $porcentajeD = trim($_POST["porcentajeD"] ?? 0);
     $destacado = trim($_POST["destacado"] ?? "") == "true" ? 1 : 0;
+    $token = $_POST["csrf_token"] ?? "";
+
+    if (!validate_csrf_token($token)) {
+        echo json_encode(["status" => "error", "message" => "Token CSRF inválido."]);
+        exit;
+    }
 
     if (empty($nombre) || empty($precio) || empty($sku) || empty($descripcion) || empty($categoria) || empty($subcategoria) || empty($rutasImagenes) || empty($atributo)) {
         echo json_encode(["status" => "error", "message" => "Todos los campos son obligatorios."]);

--- a/src/api/products/delete_product.php
+++ b/src/api/products/delete_product.php
@@ -1,6 +1,8 @@
 <?php
 header('Content-Type: application/json');
+session_start();
 require '../../scripts/conn.php'; // Conexión a la base de datos
+require '../../scripts/csrf.php';
 
 // Verifica si la solicitud es POST
 if (
@@ -9,6 +11,15 @@ if (
 
     $data = json_decode(file_get_contents("php://input"), true);
     $id = trim($data["id"] ?? "");
+    $token = $data["csrf_token"] ?? "";
+
+    if (!validate_csrf_token($token)) {
+        echo json_encode([
+            "status" => "error",
+            "message" => "Token CSRF inválido."
+        ]);
+        exit;
+    }
 
     if (empty($id)) {
         echo json_encode([

--- a/src/api/products/edit_product.php
+++ b/src/api/products/edit_product.php
@@ -1,6 +1,8 @@
 <?php
 header('Content-Type: application/json');
+session_start();
 require '../../scripts/conn.php'; // Conexión a la base de datos
+require '../../scripts/csrf.php';
 
 // Verifica si la solicitud es POST
 if ($_SERVER["REQUEST_METHOD"] === "POST") {
@@ -52,6 +54,12 @@ if ($_SERVER["REQUEST_METHOD"] === "POST") {
     $porcentajeD = trim($_POST["porcentajeD"] ?? "");
     $id = trim($_POST["id"] ?? "");
     $destacado = trim($_POST["destacado"] ?? "") == "true" ? 1 : 0;
+    $token = $_POST["csrf_token"] ?? "";
+
+    if (!validate_csrf_token($token)) {
+        echo json_encode(["status" => "error", "message" => "Token CSRF inválido."]);
+        exit;
+    }
 
     if (
         empty($id) ||


### PR DESCRIPTION
## Summary
- add CSRF requirements to `add_product.php`
- add CSRF requirements to `edit_product.php`
- add CSRF requirements to `delete_product.php`

## Testing
- `php -l src/api/products/add_product.php`
- `php -l src/api/products/edit_product.php`
- `php -l src/api/products/delete_product.php`


------
https://chatgpt.com/codex/tasks/task_b_687d54b8af888333aaf3f5541c4148a9