### PR TITLE
Add CSRF checks for subcategory editing

### DIFF
--- a/routes/suadview/subcategories_edit.php
+++ b/routes/suadview/subcategories_edit.php
@@ -16,6 +16,8 @@ if ($privilegios !== 'administrador' && $privilegios !== 'vendedor' && $privileg
 }
 
 require '../../src/scripts/conn.php'; // Conexión a la base de datos
+require '../../src/scripts/csrf.php';
+$csrf_token = generate_csrf_token();
 
 $id = $_GET['id'];
 
@@ -521,7 +523,8 @@ if (!empty($id)) {
                         <div class="row justify-content-center">
                             <div class="col-md-10 col-lg-8">
                                 <form id="category" method="POST" data-action="<?php if (!empty($id)) echo "edit";
-                                                                                else echo "add"; ?>" onsubmit="return false;">
+else echo "add"; ?>" onsubmit="return false;">
+                                    <input type="hidden" id="csrf_token" value="<?php echo htmlspecialchars($csrf_token); ?>">
                                     <div class="mb-4">
                                         <label class="form-label" for="dm-ecom-product-name">Nombre</label>
                                         <input type="text" class="form-control" id="dm-ecom-product-name" name="dm-ecom-product-name"
@@ -604,6 +607,7 @@ if (!empty($id)) {
             const nombre = document.getElementById("dm-ecom-product-name").value.trim();
             const categoria = document.getElementById("dm-ecom-category-type").value.trim();
             const id = document.getElementById("id") ? document.getElementById("id").value.trim() : null;
+            const csrfToken = document.getElementById("csrf_token").value;
 
             if (!nombre || (action === "edit" && !id)) {
                 document.getElementById("message").textContent = "El nombre es obligatorio y el ID si estás editando.";
@@ -617,10 +621,12 @@ if (!empty($id)) {
             const body = action === "edit" ? JSON.stringify({
                 nombre,
                 categoria,
-                id
+                id,
+                csrf_token: csrfToken
             }) : JSON.stringify({
                 nombre,
-                categoria
+                categoria,
+                csrf_token: csrfToken
             });
 
             try {

--- a/src/api/subcategories/add_subcategory.php
+++ b/src/api/subcategories/add_subcategory.php
@@ -1,6 +1,8 @@
 <?php
 header('Content-Type: application/json');
+session_start();
 require '../../scripts/conn.php'; // Conexión a la base de datos
+require '../../scripts/csrf.php';
 
 // Verifica si la solicitud es POST
 if ($_SERVER["REQUEST_METHOD"] === "POST") {
@@ -8,6 +10,12 @@ if ($_SERVER["REQUEST_METHOD"] === "POST") {
     $data = json_decode(file_get_contents("php://input"), true);
     $nombre = trim($data["nombre"] ?? "");
     $categoria = trim($data["categoria"] ?? "");
+    $token = $data["csrf_token"] ?? "";
+
+    if (!validate_csrf_token($token)) {
+        echo json_encode(["status" => "error", "message" => "Token CSRF inválido."]);
+        exit;
+    }
 
     // Validación básica
     if (empty($nombre) || empty($categoria)) {

--- a/src/api/subcategories/edit_subcategory.php
+++ b/src/api/subcategories/edit_subcategory.php
@@ -1,6 +1,8 @@
 <?php
 header('Content-Type: application/json');
+session_start();
 require '../../scripts/conn.php'; // Conexión a la base de datos
+require '../../scripts/csrf.php';
 
 // Verifica si la solicitud es POST
 if ($_SERVER["REQUEST_METHOD"] === "POST") {
@@ -9,6 +11,12 @@ if ($_SERVER["REQUEST_METHOD"] === "POST") {
     $nombre = trim($data["nombre"] ?? "");
     $categoria = trim($data["categoria"] ?? "");
     $id = trim($data["id"] ?? "");
+    $token = $data["csrf_token"] ?? "";
+
+    if (!validate_csrf_token($token)) {
+        echo json_encode(["status" => "error", "message" => "Token CSRF inválido."]);
+        exit;
+    }
 
     // Validación básica
     if (empty($nombre) || empty($categoria) || empty($id)) {


### PR DESCRIPTION
## Summary
- generate CSRF token on subcategory edit page and send it in requests
- validate incoming CSRF tokens in add and edit subcategory API endpoints

## Testing
- `php -l routes/suadview/subcategories_edit.php`
- `php -l src/api/subcategories/add_subcategory.php`
- `php -l src/api/subcategories/edit_subcategory.php`


------
https://chatgpt.com/codex/tasks/task_b_687d58e599f88333b7c744c4bdbaf1a3