### PR TITLE
Add CSRF token to slider edit flow

### DIFF
--- a/routes/suadview/slider_edit.php
+++ b/routes/suadview/slider_edit.php
@@ -16,6 +16,8 @@ if ($privilegios !== 'administrador' && $privilegios !== 'vendedor' && $privileg
 }
 
 require '../../src/scripts/conn.php'; // Conexión a la base de datos
+require '../../src/scripts/csrf.php';
+$csrf_token = generate_csrf_token();
 
 $id = $_GET['id'];
 
@@ -523,7 +525,8 @@ if (!empty($id)) {
                         <div class="row justify-content-center">
                             <div class="col-md-10 col-lg-8">
                                 <form id="category" method="POST" data-action="<?php if (!empty($id)) echo "edit";
-                                                                                else echo "add"; ?>" onsubmit="return false;">
+        else echo "add"; ?>" onsubmit="return false;">
+                                    <input type="hidden" id="csrf_token" value="<?php echo htmlspecialchars($csrf_token); ?>">
                                     <div class="mb-4">
                                         <label class="form-label" for="dm-ecom-product-name">Título</label>
                                         <input type="text" class="form-control" id="dm-ecom-product-name" name="dm-ecom-product-name"
@@ -600,6 +603,7 @@ if (!empty($id)) {
             const descripcion = document.getElementById("dm-ecom-product-desc").value.trim();
             const link = document.getElementById("dm-ecom-product-link").value.trim();
             const id = document.getElementById("id") ? document.getElementById("id").value.trim() : null;
+            const csrfToken = document.getElementById("csrf_token").value;
 
             const adsDropzone = document.querySelector(".dropzone");
             Dropzone.autoDiscover = false;
@@ -637,11 +641,13 @@ if (!empty($id)) {
                 link,
                 imagen: `${Dropzone.instances[0].files}`,
                 id,
+                csrf_token: csrfToken
             }) : JSON.stringify({
                 nombre,
                 descripcion,
                 imagen: `${Dropzone.instances[0].files}`,
                 link,
+                csrf_token: csrfToken
             });
 
             try {

--- a/src/scripts/ad_logic.php
+++ b/src/scripts/ad_logic.php
@@ -1,9 +1,11 @@
 <?php
 header('Content-Type: application/json');
+session_start();
+require 'conn.php';
+require 'csrf.php';
 if ($_SERVER["REQUEST_METHOD"] === "POST") {
 
     if (isset($_FILES['image']) && !empty($_FILES['image']['name'][0])) {
-        require 'conn.php'; // Conexión a la base de datos
         require 'imgOpt.php'; // Script de conversión
 
         $imagenesSubidas = [];
@@ -31,7 +33,12 @@ if ($_SERVER["REQUEST_METHOD"] === "POST") {
     // Obtiene y limpia los datos enviados
     $id = trim($_POST["id"] ?? "");
     $url = trim($_POST["url"] ?? "");
+    $token = $_POST["csrf_token"] ?? "";
     $imagen = explode(",", $rutasImagenes)[0];
+    if (!validate_csrf_token($token)) {
+        echo json_encode(["status" => "error", "message" => "Token CSRF inválido."]);
+        exit;
+    }
     if (!isset($rutasImagenes) || empty($rutasImagenes)) {
         // No se subió ninguna imagen, obtener ambas rutas actuales
         $stmt = $pdo->prepare("SELECT imagen FROM ads WHERE id = :id");


### PR DESCRIPTION
## Summary
- add CSRF handling in `slider_edit.php`
- send the token in slider edit requests
- validate token in `ad_logic.php`

## Testing
- `php -l routes/suadview/slider_edit.php`
- `php -l src/scripts/ad_logic.php`


------
https://chatgpt.com/codex/tasks/task_b_687d5e99f3388333a2bb15403bfaf640