### PR TITLE
Add CSRF validation for attribute operations

### DIFF
--- a/routes/suadview/attributes_edit.php
+++ b/routes/suadview/attributes_edit.php
@@ -16,6 +16,8 @@ if ($privilegios !== 'administrador' && $privilegios !== 'vendedor' && $privileg
 }
 
 require '../../src/scripts/conn.php'; // Conexión a la base de datos
+require '../../src/scripts/csrf.php';
+$csrf_token = generate_csrf_token();
 
 $id = $_GET['id'];
 
@@ -522,6 +524,7 @@ if (!empty($id)) {
                             <div class="col-md-10 col-lg-8">
                                 <form id="category" method="POST" data-action="<?php if (!empty($id)) echo "edit";
                                                                                 else echo "add"; ?>" onsubmit="return false;">
+                                    <input type="hidden" id="csrf_token" value="<?php echo htmlspecialchars($csrf_token); ?>">
                                     <div class="mb-4">
                                         <label class="form-label" for="dm-ecom-product-name">Nombre</label>
                                         <input type="text" class="form-control" id="dm-ecom-product-name" name="dm-ecom-product-name"
@@ -593,11 +596,14 @@ if (!empty($id)) {
                 "/src/api/attributes/edit_attribute.php" :
                 "/src/api/attributes/add_attribute.php";
 
+            const csrfToken = document.getElementById("csrf_token").value;
             const body = action === "edit" ? JSON.stringify({
                 atributo,
-                id
+                id,
+                csrf_token: csrfToken
             }) : JSON.stringify({
-                atributo
+                atributo,
+                csrf_token: csrfToken
             });
 
             try {

--- a/src/api/attributes/add_attribute.php
+++ b/src/api/attributes/add_attribute.php
@@ -1,12 +1,20 @@
 <?php
 header('Content-Type: application/json');
+session_start();
 require '../../scripts/conn.php'; // Conexión a la base de datos
+require '../../scripts/csrf.php';
 
 // Verifica si la solicitud es POST
 if ($_SERVER["REQUEST_METHOD"] === "POST") {
     // Obtiene y limpia los datos enviados
     $data = json_decode(file_get_contents("php://input"), true);
     $atributo = trim($data["atributo"] ?? "");
+    $token = $data["csrf_token"] ?? "";
+
+    if (!validate_csrf_token($token)) {
+        echo json_encode(["status" => "error", "message" => "Token CSRF inválido."]);
+        exit;
+    }
 
     // Validación básica
     if (empty($atributo)) {

--- a/src/api/attributes/edit_attribute.php
+++ b/src/api/attributes/edit_attribute.php
@@ -1,6 +1,8 @@
 <?php
 header('Content-Type: application/json');
+session_start();
 require '../../scripts/conn.php'; // Conexión a la base de datos
+require '../../scripts/csrf.php';
 
 // Verifica si la solicitud es POST
 if ($_SERVER["REQUEST_METHOD"] === "POST") {
@@ -8,6 +10,12 @@ if ($_SERVER["REQUEST_METHOD"] === "POST") {
     $data = json_decode(file_get_contents("php://input"), true);
     $atributo = trim($data["atributo"] ?? "");
     $id = trim($data["id"] ?? "");
+    $token = $data["csrf_token"] ?? "";
+
+    if (!validate_csrf_token($token)) {
+        echo json_encode(["status" => "error", "message" => "Token CSRF inválido."]);
+        exit;
+    }
 
     // Validación básica
     if (empty($atributo)) {


### PR DESCRIPTION
## Summary
- add CSRF token generation to attribute editor view
- validate CSRF token when adding or editing attributes via API
- send CSRF token from the attribute edit view

## Testing
- `php -l src/api/attributes/add_attribute.php`
- `php -l src/api/attributes/edit_attribute.php`
- `php -l routes/suadview/attributes_edit.php`

------
https://chatgpt.com/codex/tasks/task_b_687d5fee01c88333ae2ba673bbbff2b4