### PR TITLE
Add CSRF validation for user actions

### DIFF
--- a/routes/suadview/users_edit.php
+++ b/routes/suadview/users_edit.php
@@ -15,6 +15,8 @@ if ($privilegios !== 'administrador' && $privilegios !== 'vendedor' && $privileg
 }
 
 require '../../src/scripts/conn.php'; // Conexión a la base de datos
+require '../../src/scripts/csrf.php';
+$csrf_token = generate_csrf_token();
 
 $id = $_GET['id'];
 
@@ -524,6 +526,7 @@ if (!empty($id)) {
                             <div class="col-md-10 col-lg-8">
                                 <form action="be_pages_ecom_product_edit.html" method="POST" data-action="<?php if (!empty($id)) echo "edit";
                                                                                                             else echo "add"; ?>" onsubmit="return false;">
+                                    <input type="hidden" id="csrf_token" value="<?php echo htmlspecialchars($csrf_token); ?>">
                                     <div class="mb-4">
                                         <label class="form-label" for="dm-ecom-product-id">Nombre</label>
                                         <input type="text" class="form-control" id="dm-ecom-product-id" name="dm-ecom-product-id"
@@ -608,6 +611,7 @@ if (!empty($id)) {
             const user = document.getElementById("dm-ecom-product-price");
             const formAction = form.getAttribute("data-action");
             const id = document.querySelector("input[name='id']");
+            const csrfToken = document.getElementById("csrf_token").value;
 
 
             form.addEventListener("submit", async function(event) {
@@ -619,6 +623,7 @@ if (!empty($id)) {
                 formData.append("pass", pass.value == "" ? <?php if (!empty($pass)) echo "$pass";
                                                             else echo "'default'" ?> : pass.value);
                 formData.append("id", id.value);
+                formData.append("csrf_token", csrfToken);
 
                 if (document.getElementById("dm-ecom-product-category").value != "Selecciona un privilegio") {
                     formData.append("privilegios", document.getElementById("dm-ecom-product-category").value);

--- a/src/api/users/add_user.php
+++ b/src/api/users/add_user.php
@@ -1,6 +1,8 @@
 <?php
 header('Content-Type: application/json');
+session_start();
 require '../../scripts/conn.php'; // Conexión a la base de datos
+require '../../scripts/csrf.php';
 
 // Verifica si la solicitud es POST
 if ($_SERVER["REQUEST_METHOD"] === "POST") {
@@ -9,6 +11,12 @@ if ($_SERVER["REQUEST_METHOD"] === "POST") {
     $privilegios = trim($_POST["privilegios"] ?? "");
     $user = $_POST["user"] ?? "";
     $pass = $_POST["pass"] ?? "";
+    $token = $_POST["csrf_token"] ?? "";
+
+    if (!validate_csrf_token($token)) {
+        echo json_encode(["status" => "error", "message" => "Token CSRF inválido."]);
+        exit;
+    }
 
     // Validación básica
     if (empty($nombre) || empty($privilegios) || empty($user) || empty($pass)) {

--- a/src/api/users/edit_user.php
+++ b/src/api/users/edit_user.php
@@ -1,6 +1,8 @@
 <?php
 header('Content-Type: application/json');
+session_start();
 require '../../scripts/conn.php'; // Conexión a la base de datos
+require '../../scripts/csrf.php';
 
 // Verifica si la solicitud es POST
 if ($_SERVER["REQUEST_METHOD"] === "POST") {
@@ -10,6 +12,12 @@ if ($_SERVER["REQUEST_METHOD"] === "POST") {
     $user = trim($_POST["user"] ?? "");
     $pass = trim($_POST["pass"] ?? "");
     $id = trim($_POST["id"] ?? "");
+    $token = $_POST["csrf_token"] ?? "";
+
+    if (!validate_csrf_token($token)) {
+        echo json_encode(["status" => "error", "message" => "Token CSRF inválido."]);
+        exit;
+    }
 
     // Validación básica
     if (empty($nombre) || empty($privilegios) || empty($user) || empty($pass) || empty($id)) {


### PR DESCRIPTION
## Summary
- create CSRF token on user edit page and send it with requests
- verify the token in add_user and edit_user APIs

## Testing
- `php -l routes/suadview/users_edit.php`
- `php -l src/api/users/add_user.php`
- `php -l src/api/users/edit_user.php`


------
https://chatgpt.com/codex/tasks/task_b_687d62de27888333801f29200336f676