### PR TITLE
Add CSRF tokens for ad update and order scripts

### DIFF
--- a/routes/suadview/ads.php
+++ b/routes/suadview/ads.php
@@ -16,6 +16,8 @@ if ($privilegios !== 'administrador' && $privilegios !== 'vendedor' && $privileg
 }
 
 require '../../src/scripts/conn.php'; // Conexión a la base de datos
+require '../../src/scripts/csrf.php';
+$csrf_token = generate_csrf_token();
 
 $stmt = $pdo->prepare("SELECT * FROM ads");
 $stmt->execute();
@@ -591,6 +593,7 @@ $ads = $stmt->fetchAll(PDO::FETCH_ASSOC);
                                                 <input type="text" class="form-control" id="dm-ecom-ad-1" name="dm-ecom-ad-1"
                                                     value="<?= $ads[0]["url"]; ?>" placeholder="https:/.com/categoria/producto">
                                                 <input type="hidden" name="idAd1" value="1">
+                                                <input type="hidden" id="csrf_token" value="<?php echo htmlspecialchars($csrf_token); ?>">
                                             </div>
                                         </form>
                                     </div>
@@ -697,10 +700,12 @@ $ads = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
                 const urlAd1 = document.getElementById("dm-ecom-ad-1").value;
                 const idAd1 = document.querySelector("input[name=idAd1]").value;
+                const csrfToken = document.getElementById("csrf_token").value;
 
                 let formData = new FormData();
                 formData.append("id", idAd1);
                 formData.append("url", urlAd1);
+                formData.append("csrf_token", csrfToken);
 
                 formData.append("image[]", Dropzone.instances[0].files);
 
@@ -727,10 +732,12 @@ $ads = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
                 const urlAd2 = document.getElementById("dm-ecom-ad-2").value;
                 const idAd2 = document.querySelector("input[name=idAd2]").value;
+                const csrfToken2 = document.getElementById("csrf_token").value;
 
                 let formData = new FormData();
                 formData.append("id", idAd2);
                 formData.append("url", urlAd2);
+                formData.append("csrf_token", csrfToken2);
 
                 formData.append("image[]", Dropzone.instances[1].files);
 

--- a/src/scripts/ad_logic.php
+++ b/src/scripts/ad_logic.php
@@ -4,6 +4,11 @@ session_start();
 require 'conn.php';
 require 'csrf.php';
 if ($_SERVER["REQUEST_METHOD"] === "POST") {
+    $token = $_POST["csrf_token"] ?? "";
+    if (!validate_csrf_token($token)) {
+        echo json_encode(["status" => "error", "message" => "Token CSRF inválido."]);
+        exit;
+    }
 
     if (isset($_FILES['image']) && !empty($_FILES['image']['name'][0])) {
         require 'imgOpt.php'; // Script de conversión
@@ -33,12 +38,7 @@ if ($_SERVER["REQUEST_METHOD"] === "POST") {
     // Obtiene y limpia los datos enviados
     $id = trim($_POST["id"] ?? "");
     $url = trim($_POST["url"] ?? "");
-    $token = $_POST["csrf_token"] ?? "";
-    $imagen = explode(",", $rutasImagenes)[0];
-    if (!validate_csrf_token($token)) {
-        echo json_encode(["status" => "error", "message" => "Token CSRF inválido."]);
-        exit;
-    }
+    $imagen = isset($rutasImagenes) ? explode(",", $rutasImagenes)[0] : null;
     if (!isset($rutasImagenes) || empty($rutasImagenes)) {
         // No se subió ninguna imagen, obtener ambas rutas actuales
         $stmt = $pdo->prepare("SELECT imagen FROM ads WHERE id = :id");

--- a/src/scripts/add_order.php
+++ b/src/scripts/add_order.php
@@ -1,7 +1,14 @@
 <?php
 header('Content-Type: application/json');
+session_start();
 if ($_SERVER["REQUEST_METHOD"] === "POST") {
     require("conn.php");
+    require("csrf.php");
+    $token = $_POST["csrf_token"] ?? "";
+    if (!validate_csrf_token($token)) {
+        echo json_encode(["status" => "error", "message" => "Token CSRF inválido."]);
+        exit;
+    }
     $producto_ids = $_POST["id"] ?? [];
     $carrito_id = uniqid();
 


### PR DESCRIPTION
## Summary
- include CSRF token generation on `ads.php`
- send the token in ad update requests
- validate CSRF before processing ads
- enforce CSRF checks for order creation

## Testing
- `php -l routes/suadview/ads.php`
- `php -l src/scripts/ad_logic.php`
- `php -l src/scripts/add_order.php`


------
https://chatgpt.com/codex/tasks/task_b_687d63d451e883339d3bc38c0de8fb92