### PR TITLE
Add slides API endpoints

### DIFF
--- a/src/api/slides/add_slide.php
+++ b/src/api/slides/add_slide.php
@@ -1,0 +1,51 @@
+<?php
+header('Content-Type: application/json');
+session_start();
+require '../../scripts/conn.php';
+require '../../scripts/csrf.php';
+
+if ($_SERVER["REQUEST_METHOD"] === "POST") {
+    $token = $_POST['csrf_token'] ?? '';
+    if (!validate_csrf_token($token)) {
+        echo json_encode(["status" => "error", "message" => "Token CSRF inválido."]);
+        exit;
+    }
+
+    if (isset($_FILES['image']) && !empty($_FILES['image']['name'][0])) {
+        require '../../scripts/imgOpt.php';
+        if (is_array($_FILES['image']['tmp_name'])) {
+            $fileTmpName = $_FILES['image']['tmp_name'][0];
+        } else {
+            $fileTmpName = $_FILES['image']['tmp_name'];
+        }
+        $rutaImagen = convertirImagenAWebP($fileTmpName, __DIR__ . '/../../public/img/');
+    } else {
+        echo json_encode(["status" => "error", "message" => "No se subió imagen."]);
+        exit;
+    }
+
+    $titulo = trim($_POST['titulo'] ?? '');
+    $descripcion = trim($_POST['descripcion'] ?? '');
+    $enlace = trim($_POST['enlace'] ?? '');
+
+    if (empty($titulo) || empty($enlace) || empty($rutaImagen)) {
+        echo json_encode(["status" => "error", "message" => "Todos los campos son obligatorios."]);
+        exit;
+    }
+
+    try {
+        $stmt = $pdo->prepare("INSERT INTO slides (titulo, descripcion, enlace, imagen) VALUES (:titulo, :descripcion, :enlace, :imagen)");
+        $stmt->execute([
+            'titulo' => $titulo,
+            'descripcion' => $descripcion,
+            'enlace' => $enlace,
+            'imagen' => $rutaImagen
+        ]);
+        echo json_encode(["status" => "success", "message" => "Slide agregado correctamente."]);
+    } catch (PDOException $e) {
+        echo json_encode(["status" => "error", "message" => "Error al agregar el slide: " . $e->getMessage()]);
+    }
+} else {
+    echo json_encode(["status" => "error", "message" => "Método no permitido."]);
+}
+?>

--- a/src/api/slides/delete_slide.php
+++ b/src/api/slides/delete_slide.php
@@ -1,0 +1,32 @@
+<?php
+header('Content-Type: application/json');
+session_start();
+require '../../scripts/conn.php';
+require '../../scripts/csrf.php';
+
+if ($_SERVER["REQUEST_METHOD"] === "POST") {
+    $data = json_decode(file_get_contents("php://input"), true);
+    $id = trim($data['id'] ?? '');
+    $token = $data['csrf_token'] ?? '';
+
+    if (!validate_csrf_token($token)) {
+        echo json_encode(["status" => "error", "message" => "Token CSRF inválido."]);
+        exit;
+    }
+
+    if (empty($id)) {
+        echo json_encode(["status" => "error", "message" => "El id es obligatorio."]);
+        exit;
+    }
+
+    try {
+        $stmt = $pdo->prepare("DELETE FROM slides WHERE id=:id");
+        $stmt->execute(['id' => $id]);
+        echo json_encode(["status" => "success", "message" => "Slide eliminado correctamente."]);
+    } catch (PDOException $e) {
+        echo json_encode(["status" => "error", "message" => "Error al eliminar el slide: " . $e->getMessage()]);
+    }
+} else {
+    echo json_encode(["status" => "error", "message" => "Método no permitido."]);
+}
+?>

--- a/src/api/slides/edit_slide.php
+++ b/src/api/slides/edit_slide.php
@@ -1,0 +1,59 @@
+<?php
+header('Content-Type: application/json');
+session_start();
+require '../../scripts/conn.php';
+require '../../scripts/csrf.php';
+
+if ($_SERVER["REQUEST_METHOD"] === "POST") {
+    $token = $_POST['csrf_token'] ?? '';
+    if (!validate_csrf_token($token)) {
+        echo json_encode(["status" => "error", "message" => "Token CSRF inválido."]);
+        exit;
+    }
+
+    $id = trim($_POST['id'] ?? '');
+    if (empty($id)) {
+        echo json_encode(["status" => "error", "message" => "El id es obligatorio."]);
+        exit;
+    }
+
+    if (isset($_FILES['image']) && !empty($_FILES['image']['name'][0])) {
+        require '../../scripts/imgOpt.php';
+        if (is_array($_FILES['image']['tmp_name'])) {
+            $fileTmpName = $_FILES['image']['tmp_name'][0];
+        } else {
+            $fileTmpName = $_FILES['image']['tmp_name'];
+        }
+        $rutaImagen = convertirImagenAWebP($fileTmpName, __DIR__ . '/../../public/img/');
+    } else {
+        $stmtImg = $pdo->prepare("SELECT imagen FROM slides WHERE id = :id");
+        $stmtImg->execute(['id' => $id]);
+        $rutaImagen = $stmtImg->fetchColumn();
+    }
+
+    $titulo = trim($_POST['titulo'] ?? '');
+    $descripcion = trim($_POST['descripcion'] ?? '');
+    $enlace = trim($_POST['enlace'] ?? '');
+
+    if (empty($titulo) || empty($enlace) || empty($rutaImagen)) {
+        echo json_encode(["status" => "error", "message" => "Todos los campos son obligatorios."]);
+        exit;
+    }
+
+    try {
+        $stmt = $pdo->prepare("UPDATE slides SET titulo=:titulo, descripcion=:descripcion, enlace=:enlace, imagen=:imagen WHERE id=:id");
+        $stmt->execute([
+            'titulo' => $titulo,
+            'descripcion' => $descripcion,
+            'enlace' => $enlace,
+            'imagen' => $rutaImagen,
+            'id' => $id
+        ]);
+        echo json_encode(["status" => "success", "message" => "Slide editado correctamente."]);
+    } catch (PDOException $e) {
+        echo json_encode(["status" => "error", "message" => "Error al editar el slide: " . $e->getMessage()]);
+    }
+} else {
+    echo json_encode(["status" => "error", "message" => "Método no permitido."]);
+}
+?>

--- a/src/api/slides/read_slides.php
+++ b/src/api/slides/read_slides.php
@@ -1,0 +1,17 @@
+<?php
+header('Content-Type: application/json');
+require '../../scripts/conn.php';
+
+if ($_SERVER["REQUEST_METHOD"] === "GET") {
+    try {
+        $stmt = $pdo->prepare("SELECT * FROM slides ORDER BY id DESC");
+        $stmt->execute();
+        $slides = $stmt->fetchAll(PDO::FETCH_ASSOC);
+        echo json_encode(["status" => "success", "message" => "Slides listados correctamente.", "data" => $slides]);
+    } catch (PDOException $e) {
+        echo json_encode(["status" => "error", "message" => "Error al listar los slides: " . $e->getMessage()]);
+    }
+} else {
+    echo json_encode(["status" => "error", "message" => "Método no permitido."]);
+}
+?>


### PR DESCRIPTION
## Summary
- add slide CRUD endpoints in `src/api/slides`
- handle image upload via `imgOpt.php`

## Testing
- `php -l src/api/slides/add_slide.php`
- `php -l src/api/slides/edit_slide.php`
- `php -l src/api/slides/delete_slide.php`
- `php -l src/api/slides/read_slides.php`


------
https://chatgpt.com/codex/tasks/task_b_687d6a6b6dc48333a01d376cd84beaff