### PR TITLE
Add overlay to slider images

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -678,12 +678,26 @@ nav ul a li {
 }
 
 .slider .box-img {
-	width: 50%;
-	height: 100%;
+        width: 50%;
+        height: 100%;
+        position: relative;
+}
+
+.slider .box-img::after {
+        content: "";
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background: rgba(0, 0, 0, 0.4);
+        z-index: 1;
 }
 
 .slider .box-img img {
-	object-fit: contain;
+        object-fit: contain;
+        position: relative;
+        z-index: 0;
 }
 
 .slider .slide-content {
@@ -696,14 +710,16 @@ nav ul a li {
 }
 
 .slider .slide-content .product-info {
-	width: 50%;
-	height: 100%;
-	padding: 2em 3em;
-	display: flex;
-	justify-content: center;
-	gap: 3em;
-	align-items: center;
-	flex-direction: column;
+        width: 50%;
+        height: 100%;
+        padding: 2em 3em;
+        display: flex;
+        justify-content: center;
+        gap: 3em;
+        align-items: center;
+        flex-direction: column;
+        position: relative;
+        z-index: 2;
 }
 
 .slider .slide-content .product-info .product-title {


### PR DESCRIPTION
## Summary
- add a dark overlay to slider images using a `::after` pseudo-element
- keep slide text above the overlay

## Testing
- `php -l index.php`

------
https://chatgpt.com/codex/tasks/task_b_687d6d2f49108333a3577ca210825a1e