### PR TITLE
Fix search URL and sanitize product data

### DIFF
--- a/public/js/search.js
+++ b/public/js/search.js
@@ -1,3 +1,9 @@
+function escapeHtml(text) {
+    const div = document.createElement('div');
+    div.textContent = text;
+    return div.innerHTML;
+}
+
 export default function searchProducts() {
 	const searchInput = document.getElementById("searchInput");
 	const resultsContainer = document.getElementById("results-container");
@@ -6,31 +12,29 @@ export default function searchProducts() {
 	searchInput.addEventListener("input", function () {
 		const query = searchInput.value;
 
-		if (query.length > 0) {
-			fetch(`/src/api/products/read_by_name.php?name=${query}`)
+                if (query.length > 0) {
+                        fetch(`${BASE_URL}src/api/products/read_by_name.php?name=${query}`)
 				.then((response) => response.json())
 				.then((data) => {
 					resultsContainer.innerHTML = "";
-					data.data.forEach((product) => {
-						const productItem = document.createElement("a");
-						productItem.href = `/producto/${product.nombre
-							.replaceAll(" ", "-")
-							.toLowerCase()}?id=${product.id}`;
-						productItem.innerHTML = `
+                                        data.data.forEach((product) => {
+                                                const productItem = document.createElement("a");
+                                                const safeName = escapeHtml(product.nombre);
+                                                const safeDesc = escapeHtml(product.descripcion);
+                                                productItem.href = `/producto/${product.nombre
+                                                        .replaceAll(" ", "-")
+                                                        .toLowerCase()}?id=${product.id}`;
+                                                productItem.innerHTML = `
                             <div class="box-img">
-                                <img src="${
-																	product.imagen.split(",")[0]
-																}" alt="${product.nombre}">
+                                <img src="${product.imagen.split(",")[0]}" alt="${safeName}">
                             </div>
                             <div class="box-text">
-                                <h3>${product.nombre}</h3>
-                                <p class="product-description">${
-																	product.descripcion
-																}</p>
+                                <h3>${safeName}</h3>
+                                <p class="product-description">${safeDesc}</p>
                                 <p class="price">$${
-																	product.descuento > 0
-																		? product.precioD
-																		: product.precio
+                                                                               product.descuento > 0
+                                                                               ? product.precioD
+                                                                               : product.precio
 																}</p>
                             </div>
                             `;

--- a/src/api/products/read_by_name.php
+++ b/src/api/products/read_by_name.php
@@ -12,6 +12,13 @@ if ($_SERVER["REQUEST_METHOD"] === "GET") {
 
         $productos = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
+        foreach ($productos as &$producto) {
+            if (isset($producto['descripcion'])) {
+                $producto['descripcion'] = htmlspecialchars($producto['descripcion'], ENT_QUOTES, 'UTF-8');
+            }
+        }
+        unset($producto);
+
         echo json_encode(["status" => "success", "message" => "Productos listados correctamente.", "data" => $productos]);
     } catch (PDOException $e) {
         echo json_encode(["status" => "error", "message" => "Error al listar los productos: " . $e->getMessage()]);


### PR DESCRIPTION
## Summary
- use BASE_URL when searching
- escape user-provided text in search results
- sanitize descriptions server-side

## Testing
- `php -l src/api/products/read_by_name.php`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6884ed5e585883339f38dae1e05f4305