### PR TITLE
Validate product ID before queries

### DIFF
--- a/routes/producto.php
+++ b/routes/producto.php
@@ -1,11 +1,17 @@
 <?php
 require '../src/scripts/conn.php'; // Conexión a la base de datos
 
+$id = $_GET['id'] ?? "";
+if (!is_numeric($id)) {
+    header('Location: /');
+    exit();
+}
+
 require '../src/scripts/allVisits.php';
 
 // Incrementar el contador de visitas
 $visitasP = $pdo->prepare("UPDATE productos SET visitas = visitas + 1 WHERE id = ?");
-$visitasP->execute([$_GET['id']]);
+$visitasP->execute([$id]);
 
 $title = "Piel Canela | Producto";
 $description = "Transforma tu rutina de belleza con SK. Este producto ofrece resultados visibles y de alta calidad. ¡Compra ahora y experimenta la diferencia!";
@@ -33,7 +39,7 @@ $description = "Transforma tu rutina de belleza con SK. Este producto ofrece res
         <?php
 
         $sql = $pdo->prepare("SELECT p.*, a.atributo AS atributo FROM productos AS p JOIN atributos AS a ON p.atributo_id = a.id WHERE p.id = ?");
-        $sql->execute([$_GET['id']]);
+        $sql->execute([$id]);
 
         $producto = $sql->fetchAll(PDO::FETCH_ASSOC);
 


### PR DESCRIPTION
## Summary
- ensure `routes/producto.php` checks that the product ID exists and is numeric
- only run visit tracking and product queries when the ID is valid

## Testing
- `php -l routes/producto.php`


------
https://chatgpt.com/codex/tasks/task_b_6884ed7fd81c8333a48fdd37c4cb4b45