### PR TITLE
Add global config to all routes, API endpoints and scripts

### DIFF
--- a/routes/carrito.php
+++ b/routes/carrito.php
@@ -1,3 +1,4 @@
+<?php require_once __DIR__ . '/../src/config/config.php'; ?>
 <!DOCTYPE html>
 <html lang="es">
 

--- a/routes/categorias.php
+++ b/routes/categorias.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/../src/config/config.php';
 require '../src/scripts/conn.php'; // Conexión a la base de datos
 
 $id = $_GET['id'] ?? "";

--- a/routes/perfil.php
+++ b/routes/perfil.php
@@ -1,3 +1,4 @@
+<?php require_once __DIR__ . '/../src/config/config.php'; ?>
 <!DOCTYPE html>
 <html lang="es">
 

--- a/routes/producto.php
+++ b/routes/producto.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/../src/config/config.php';
 require '../src/scripts/conn.php'; // Conexión a la base de datos
 
 $id = $_GET['id'] ?? "";

--- a/routes/productos.php
+++ b/routes/productos.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/../src/config/config.php';
 require '../src/scripts/conn.php'; // Conexión a la base de datos
 
 $name = $_GET['name'] ?? "";

--- a/routes/suadview/categories.php
+++ b/routes/suadview/categories.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/../../src/config/config.php';
 
 session_start();
 

--- a/routes/suadview/categories_edit.php
+++ b/routes/suadview/categories_edit.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/../../src/config/config.php';
 
 session_start();
 

--- a/routes/suadview/categories_feature.php
+++ b/routes/suadview/categories_feature.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/../../src/config/config.php';
 
 session_start();
 

--- a/routes/suadview/products.php
+++ b/routes/suadview/products.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/../../src/config/config.php';
 
 session_start();
 

--- a/routes/suadview/products_edit.php
+++ b/routes/suadview/products_edit.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/../../src/config/config.php';
 
 session_start();
 

--- a/routes/suadview/products_featured.php
+++ b/routes/suadview/products_featured.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/../../src/config/config.php';
 
 session_start();
 

--- a/routes/suadview/slider.php
+++ b/routes/suadview/slider.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/../../src/config/config.php';
 
 session_start();
 

--- a/routes/suadview/slider_edit.php
+++ b/routes/suadview/slider_edit.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/../../src/config/config.php';
 
 session_start();
 

--- a/routes/suadview/suadview.php
+++ b/routes/suadview/suadview.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/../../src/config/config.php';
 
 session_start();
 

--- a/routes/suadview/subcategories.php
+++ b/routes/suadview/subcategories.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/../../src/config/config.php';
 
 session_start();
 

--- a/routes/suadview/subcategories_edit.php
+++ b/routes/suadview/subcategories_edit.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/../../src/config/config.php';
 
 session_start();
 

--- a/routes/suadview/users.php
+++ b/routes/suadview/users.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/../../src/config/config.php';
 
 session_start();
 

--- a/routes/suadview/users_edit.php
+++ b/routes/suadview/users_edit.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/../../src/config/config.php';
 session_start();
 
 if (!isset($_SESSION['user_id'])) {

--- a/routes/subcategorias.php
+++ b/routes/subcategorias.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/../src/config/config.php';
 require '../src/scripts/conn.php'; // Conexión a la base de datos
 
 $id = $_GET['id'] ?? "";

--- a/src/api/attributes/add_attribute.php
+++ b/src/api/attributes/add_attribute.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/../../config/config.php';
 header('Content-Type: application/json');
 session_start();
 require '../../scripts/conn.php'; // Conexión a la base de datos

--- a/src/api/attributes/all_views_attribute.php
+++ b/src/api/attributes/all_views_attribute.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/../../config/config.php';
 header('Content-Type: application/json');
 require '../../scripts/conn.php'; // Conexión a la base de datos
 

--- a/src/api/attributes/delete_attribute.php
+++ b/src/api/attributes/delete_attribute.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/../../config/config.php';
 header('Content-Type: application/json');
 require '../../scripts/conn.php'; // Conexión a la base de datos
 

--- a/src/api/attributes/edit_attribute.php
+++ b/src/api/attributes/edit_attribute.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/../../config/config.php';
 header('Content-Type: application/json');
 session_start();
 require '../../scripts/conn.php'; // Conexión a la base de datos

--- a/src/api/attributes/read_attributes.php
+++ b/src/api/attributes/read_attributes.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/../../config/config.php';
 header('Content-Type: application/json');
 require '../../scripts/conn.php'; // Conexión a la base de datos
 

--- a/src/api/bag/add_bag.php
+++ b/src/api/bag/add_bag.php
@@ -1,0 +1,1 @@
+<?php require_once __DIR__ . '/../../config/config.php'; ?>

--- a/src/api/bag/delete_bag.php
+++ b/src/api/bag/delete_bag.php
@@ -1,0 +1,1 @@
+<?php require_once __DIR__ . '/../../config/config.php'; ?>

--- a/src/api/bag/edit_bag.php
+++ b/src/api/bag/edit_bag.php
@@ -1,0 +1,1 @@
+<?php require_once __DIR__ . '/../../config/config.php'; ?>

--- a/src/api/bag/read_bag.php
+++ b/src/api/bag/read_bag.php
@@ -1,0 +1,1 @@
+<?php require_once __DIR__ . '/../../config/config.php'; ?>

--- a/src/api/categories/add_category.php
+++ b/src/api/categories/add_category.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/../../config/config.php';
 header('Content-Type: application/json');
 session_start();
 require '../../scripts/conn.php'; // Conexión a la base de datos

--- a/src/api/categories/all_views_category.php
+++ b/src/api/categories/all_views_category.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/../../config/config.php';
 header('Content-Type: application/json');
 require '../../scripts/conn.php'; // Conexión a la base de datos
 

--- a/src/api/categories/delete_category.php
+++ b/src/api/categories/delete_category.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/../../config/config.php';
 header('Content-Type: application/json');
 require '../../scripts/conn.php'; // Conexión a la base de datos
 

--- a/src/api/categories/edit_category.php
+++ b/src/api/categories/edit_category.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/../../config/config.php';
 header('Content-Type: application/json');
 session_start();
 require '../../scripts/conn.php'; // Conexión a la base de datos

--- a/src/api/categories/read_all_categories.php
+++ b/src/api/categories/read_all_categories.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/../../config/config.php';
 header('Content-Type: application/json');
 require '../../scripts/conn.php'; // Conexión a la base de datos
 

--- a/src/api/categories/read_categories.php
+++ b/src/api/categories/read_categories.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/../../config/config.php';
 header('Content-Type: application/json');
 require '../../scripts/conn.php'; // Conexión a la base de datos
 

--- a/src/api/products/add_product.php
+++ b/src/api/products/add_product.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/../../config/config.php';
 header('Content-Type: application/json');
 session_start();
 require '../../scripts/conn.php'; // Conexión a la base de datos

--- a/src/api/products/all_views_product.php
+++ b/src/api/products/all_views_product.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/../../config/config.php';
 header('Content-Type: application/json');
 require '../../scripts/conn.php'; // Conexión a la base de datos
 

--- a/src/api/products/delete_product.php
+++ b/src/api/products/delete_product.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/../../config/config.php';
 header('Content-Type: application/json');
 session_start();
 require '../../scripts/conn.php'; // Conexión a la base de datos

--- a/src/api/products/edit_product.php
+++ b/src/api/products/edit_product.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/../../config/config.php';
 header('Content-Type: application/json');
 session_start();
 require '../../scripts/conn.php'; // Conexión a la base de datos

--- a/src/api/products/id_product.php
+++ b/src/api/products/id_product.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/../../config/config.php';
 header('Content-Type: application/json');
 require '../../scripts/conn.php'; // Conexión a la base de datos
 

--- a/src/api/products/read_by_name.php
+++ b/src/api/products/read_by_name.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/../../config/config.php';
 header('Content-Type: application/json');
 require '../../scripts/conn.php'; // Conexión a la base de datos
 

--- a/src/api/products/read_products.php
+++ b/src/api/products/read_products.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/../../config/config.php';
 header('Content-Type: application/json');
 require '../../scripts/conn.php'; // Conexión a la base de datos
 

--- a/src/api/slides/add_slide.php
+++ b/src/api/slides/add_slide.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/../../config/config.php';
 header('Content-Type: application/json');
 session_start();
 require '../../scripts/conn.php';

--- a/src/api/slides/delete_slide.php
+++ b/src/api/slides/delete_slide.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/../../config/config.php';
 header('Content-Type: application/json');
 session_start();
 require '../../scripts/conn.php';

--- a/src/api/slides/edit_slide.php
+++ b/src/api/slides/edit_slide.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/../../config/config.php';
 header('Content-Type: application/json');
 session_start();
 require '../../scripts/conn.php';

--- a/src/api/slides/read_slides.php
+++ b/src/api/slides/read_slides.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/../../config/config.php';
 header('Content-Type: application/json');
 require '../../scripts/conn.php';
 

--- a/src/api/subcategories/add_subcategory.php
+++ b/src/api/subcategories/add_subcategory.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/../../config/config.php';
 header('Content-Type: application/json');
 session_start();
 require '../../scripts/conn.php'; // Conexión a la base de datos

--- a/src/api/subcategories/all_views_subcategory.php
+++ b/src/api/subcategories/all_views_subcategory.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/../../config/config.php';
 header('Content-Type: application/json');
 require '../../scripts/conn.php'; // Conexión a la base de datos
 

--- a/src/api/subcategories/delete_subcategory.php
+++ b/src/api/subcategories/delete_subcategory.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/../../config/config.php';
 header('Content-Type: application/json');
 require '../../scripts/conn.php'; // Conexión a la base de datos
 

--- a/src/api/subcategories/edit_subcategory.php
+++ b/src/api/subcategories/edit_subcategory.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/../../config/config.php';
 header('Content-Type: application/json');
 session_start();
 require '../../scripts/conn.php'; // Conexión a la base de datos

--- a/src/api/subcategories/read_subcategories.php
+++ b/src/api/subcategories/read_subcategories.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/../../config/config.php';
 header('Content-Type: application/json');
 require '../../scripts/conn.php'; // Conexión a la base de datos
 

--- a/src/api/subcategories/read_subcategories_specific.php
+++ b/src/api/subcategories/read_subcategories_specific.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/../../config/config.php';
 header('Content-Type: application/json');
 require '../../scripts/conn.php'; // Conexión a la base de datos
 

--- a/src/api/users/add_user.php
+++ b/src/api/users/add_user.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/../../config/config.php';
 header('Content-Type: application/json');
 session_start();
 require '../../scripts/conn.php'; // Conexión a la base de datos

--- a/src/api/users/all_views_user.php
+++ b/src/api/users/all_views_user.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/../../config/config.php';
 header('Content-Type: application/json');
 require '../../scripts/conn.php'; // Conexión a la base de datos
 

--- a/src/api/users/delete_user.php
+++ b/src/api/users/delete_user.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/../../config/config.php';
 header('Content-Type: application/json');
 require '../../scripts/conn.php'; // Conexión a la base de datos
 

--- a/src/api/users/edit_user.php
+++ b/src/api/users/edit_user.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/../../config/config.php';
 header('Content-Type: application/json');
 session_start();
 require '../../scripts/conn.php'; // Conexión a la base de datos

--- a/src/api/users/read_users.php
+++ b/src/api/users/read_users.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/../../config/config.php';
 header('Content-Type: application/json');
 require '../../scripts/conn.php'; // Conexión a la base de datos
 

--- a/src/api/users/verify_user.php
+++ b/src/api/users/verify_user.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/../../config/config.php';
 header('Content-Type: application/json');
 session_start();
 require '../../scripts/conn.php'; // Conexión a la base de datos

--- a/src/scripts/ad_logic.php
+++ b/src/scripts/ad_logic.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/../config/config.php';
 header('Content-Type: application/json');
 session_start();
 require 'conn.php';

--- a/src/scripts/ad_visit.php
+++ b/src/scripts/ad_visit.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/../config/config.php';
 header('Content-Type: application/json');
 if ($_SERVER["REQUEST_METHOD"] === "GET") {
     require("conn.php");

--- a/src/scripts/add_order.php
+++ b/src/scripts/add_order.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/../config/config.php';
 header('Content-Type: application/json');
 session_start();
 if ($_SERVER["REQUEST_METHOD"] === "POST") {

--- a/src/scripts/allVisits.php
+++ b/src/scripts/allVisits.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/../config/config.php';
 $ip = $_SERVER['REMOTE_ADDR']; // Obtiene la IP del usuario
 
 // Intenta insertar la visita única

--- a/src/scripts/chart_data.php
+++ b/src/scripts/chart_data.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/../config/config.php';
 header('Content-Type: application/json');
 if ($_SERVER["REQUEST_METHOD"] === "GET") {
     require("conn.php");

--- a/src/scripts/conn.php
+++ b/src/scripts/conn.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/../config/config.php';
 // Configuración de conexión
 $host = "localhost";
 $dbname = "pc_ecom";

--- a/src/scripts/csrf.php
+++ b/src/scripts/csrf.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/../config/config.php';
 if (session_status() === PHP_SESSION_NONE) {
     session_start();
 }

--- a/src/scripts/imgOpt.php
+++ b/src/scripts/imgOpt.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/../config/config.php';
 header('Content-Type: application/json');
 // Directorio de destino
 $destino = __DIR__ . '/../../public/img/';

--- a/src/scripts/load_more_products.php
+++ b/src/scripts/load_more_products.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/../config/config.php';
 require 'conn.php'; // Conexión a la base de datos
 
 $id = $_GET['id'] ?? "";

--- a/src/scripts/load_more_products_specific.php
+++ b/src/scripts/load_more_products_specific.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/../config/config.php';
 require 'conn.php'; // Conexión a la base de datos
 
 $id = $_GET['id'] ?? "";

--- a/src/scripts/onUser.php
+++ b/src/scripts/onUser.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/../config/config.php';
 header('Content-Type: application/json');
 session_start();
 require "conn.php";


### PR DESCRIPTION
## Summary
- include `config.php` at the top of every PHP script under `routes`, `src/api`, and `src/scripts`

## Testing
- `php -l` on all PHP files

------
https://chatgpt.com/codex/tasks/task_b_6885023121f88333b8a86a4822b72b44