### PR TITLE
Update featured query ordering

### DIFF
--- a/index.php
+++ b/index.php
@@ -62,7 +62,7 @@ require 'src/scripts/allVisits.php';
 			</div>
 			<div class="productos-list">
 				<?php
-				$sql = $pdo->prepare("SELECT p.*, a.atributo AS atributo FROM productos AS p JOIN atributos AS a ON p.atributo_id = a.id ORDER BY visitas DESC LIMIT 8");
+                                $sql = $pdo->prepare("SELECT p.*, a.atributo AS atributo FROM productos AS p JOIN atributos AS a ON p.atributo_id = a.id ORDER BY p.destacado DESC, p.visitas DESC LIMIT 8");
 				$sql->execute();
 
 				$productos = $sql->fetchAll(PDO::FETCH_ASSOC);

--- a/routes/categorias.php
+++ b/routes/categorias.php
@@ -60,7 +60,7 @@ $description = "Explora nuestras categorías en SK. Encuentra una amplia selecci
                     } elseif ($price === "desc") {
                         $statement = "SELECT p.*, a.atributo FROM productos p JOIN atributos a ON p.atributo_id = a.id WHERE categoria = ? ORDER BY precio DESC LIMIT 16";
                     } elseif ($featured === "1") {
-                        $statement = "SELECT p.*, a.atributo FROM productos p JOIN atributos a ON p.atributo_id = a.id WHERE categoria = ? ORDER BY visitas DESC LIMIT 16";
+                        $statement = "SELECT p.*, a.atributo FROM productos p JOIN atributos a ON p.atributo_id = a.id WHERE categoria = ? ORDER BY p.destacado DESC, p.visitas DESC LIMIT 16";
                     } elseif ($discount === "1") {
                         $statement = "SELECT p.*, a.atributo FROM productos p JOIN atributos a ON p.atributo_id = a.id WHERE categoria = ? AND descuento = 1 ORDER BY precioD ASC LIMIT 16";
                     } else {

--- a/routes/productos.php
+++ b/routes/productos.php
@@ -64,7 +64,7 @@ $description = "Explora nuestros productos en SK. Encuentra una amplia selecció
                     } elseif (!empty($price) && $price === "desc") {
                         $statement = "SELECT p.*, a.atributo AS atributo FROM productos AS p JOIN atributos AS a ON p.atributo_id = a.id WHERE p.nombre LIKE ? ORDER BY precio DESC LIMIT 16";
                     } elseif (!empty($featured) && $featured === "1") {
-                        $statement = "SELECT p.*, a.atributo AS atributo FROM productos AS p JOIN atributos AS a ON p.atributo_id = a.id WHERE p.nombre LIKE ? ORDER BY visitas DESC LIMIT 16";
+                        $statement = "SELECT p.*, a.atributo AS atributo FROM productos AS p JOIN atributos AS a ON p.atributo_id = a.id WHERE p.nombre LIKE ? ORDER BY p.destacado DESC, p.visitas DESC LIMIT 16";
                     } elseif (!empty($discount) && $discount === "1") {
                         $statement = "SELECT p.*, a.atributo AS atributo FROM productos AS p JOIN atributos AS a ON p.atributo_id = a.id WHERE p.nombre LIKE ? AND descuento = 1 ORDER BY precioD ASC LIMIT 16";
                     } else {

--- a/routes/subcategorias.php
+++ b/routes/subcategorias.php
@@ -74,7 +74,7 @@ $description = "Explora nuestras subcategorías en SK. Encuentra una amplia sele
                     } elseif (!empty($price) && $price === "desc") {
                         $statement = "SELECT p.*, a.atributo AS atributo FROM productos AS p JOIN atributos AS a ON p.atributo_id = a.id JOIN subcategorias AS s ON p.subcategoria = s.id AND p.categoria = s.id_categoria WHERE s.id = ? ORDER BY precio DESC LIMIT 16";
                     } elseif (!empty($featured) && $featured === "1") {
-                        $statement = "SELECT p.*, a.atributo AS atributo FROM productos AS p JOIN atributos AS a ON p.atributo_id = a.id JOIN subcategorias AS s ON p.subcategoria = s.id AND p.categoria = s.id_categoria WHERE s.id = ? ORDER BY visitas DESC LIMIT 16";
+                        $statement = "SELECT p.*, a.atributo AS atributo FROM productos AS p JOIN atributos AS a ON p.atributo_id = a.id JOIN subcategorias AS s ON p.subcategoria = s.id AND p.categoria = s.id_categoria WHERE s.id = ? ORDER BY p.destacado DESC, p.visitas DESC LIMIT 16";
                     } elseif (!empty($discount) && $discount === "1") {
                         $statement = "SELECT p.*, a.atributo AS atributo FROM productos AS p JOIN atributos AS a ON p.atributo_id = a.id JOIN subcategorias AS s ON p.subcategoria = s.id AND p.categoria = s.id_categoria WHERE s.id = ? AND descuento = 1 ORDER BY precioD ASC LIMIT 16";
                     } else {

--- a/src/scripts/load_more_products.php
+++ b/src/scripts/load_more_products.php
@@ -15,7 +15,7 @@ if (!empty($price) && $price === "asc") {
 } else if (!empty($price) && $price === "desc") {
     $statement = "SELECT * FROM productos WHERE categoria = ? ORDER BY price DESC LIMIT ? OFFSET ?";
 } else if (!empty($featured) && $featured === "1") {
-    $statement = "SELECT * FROM productos WHERE categoria = ? ORDER BY visitas DESC LIMIT ? OFFSET ?";
+    $statement = "SELECT * FROM productos WHERE categoria = ? ORDER BY destacado DESC, visitas DESC LIMIT ? OFFSET ?";
 } else if (!empty($discount) && $discount === "1") {
     $statement = "SELECT * FROM productos WHERE categoria = ? AND descuento = 1 ORDER BY precioD ASC LIMIT ? OFFSET ?";
 } else {

--- a/src/scripts/load_more_products_specific.php
+++ b/src/scripts/load_more_products_specific.php
@@ -15,7 +15,7 @@ if (!empty($price) && $price === "asc") {
 } elseif (!empty($price) && $price === "desc") {
     $statement = "SELECT p.*, a.atributo AS atributo FROM productos AS p JOIN atributos AS a ON p.atributo_id = a.id JOIN subcategorias AS s ON p.subcategoria = s.id AND p.categoria = s.id_categoria WHERE s.id = ? ORDER BY precio DESC LIMIT ? OFFSET ?";
 } elseif (!empty($featured) && $featured === "1") {
-    $statement = "SELECT p.*, a.atributo AS atributo FROM productos AS p JOIN atributos AS a ON p.atributo_id = a.id JOIN subcategorias AS s ON p.subcategoria = s.id AND p.categoria = s.id_categoria WHERE s.id = ? ORDER BY visitas DESC LIMIT ? OFFSET ?";
+    $statement = "SELECT p.*, a.atributo AS atributo FROM productos AS p JOIN atributos AS a ON p.atributo_id = a.id JOIN subcategorias AS s ON p.subcategoria = s.id AND p.categoria = s.id_categoria WHERE s.id = ? ORDER BY p.destacado DESC, p.visitas DESC LIMIT ? OFFSET ?";
 } elseif (!empty($discount) && $discount === "1") {
     $statement = "SELECT p.*, a.atributo AS atributo FROM productos AS p JOIN atributos AS a ON p.atributo_id = a.id JOIN subcategorias AS s ON p.subcategoria = s.id AND p.categoria = s.id_categoria WHERE s.id = ? AND descuento = 1 ORDER BY precioD ASC LIMIT ? OFFSET ?";
 } else {


### PR DESCRIPTION
## Summary
- show featured products first on the home page
- update all "featured" filters across search and category pages to order by featured flag then visits
- keep paging scripts consistent with the new ordering

## Testing
- `php -l index.php`
- `php -l routes/productos.php`
- `php -l routes/categorias.php`
- `php -l routes/subcategorias.php`
- `php -l src/scripts/load_more_products.php`
- `php -l src/scripts/load_more_products_specific.php`


------
https://chatgpt.com/codex/tasks/task_b_688573f327408333b6563f4767a6c8b0