### PR TITLE
Track category visits and expose visit counts

### DIFF
--- a/routes/categorias.php
+++ b/routes/categorias.php
@@ -12,6 +12,7 @@ if (empty($id)) {
     exit();
 }
 
+require '../src/scripts/categoryVisits.php';
 require '../src/scripts/allVisits.php';
 
 $title = "Piel Canela | Categorías";

--- a/src/api/categories/read_all_categories.php
+++ b/src/api/categories/read_all_categories.php
@@ -12,6 +12,7 @@ if ($_SERVER["REQUEST_METHOD"] === "GET") {
                 c.id AS categoria_id,
                 c.nombre AS categoria_nombre,
                 c.imagen AS categoria_imagen,
+                c.visitas AS categoria_visitas,
                 s.id AS subcategoria_id,
                 s.nombre AS subcategoria_nombre
             FROM categorias AS c
@@ -33,6 +34,7 @@ if ($_SERVER["REQUEST_METHOD"] === "GET") {
                     'id' => $catId,
                     'nombre' => $row['categoria_nombre'],
                     'imagen' => !empty($row['categoria_imagen']) ? BASE_URL . ltrim($row['categoria_imagen'], '/') : null,
+                    'visitas' => (int) $row['categoria_visitas'],
                     'subcategorias' => []
                 ];
             }

--- a/src/scripts/categoryVisits.php
+++ b/src/scripts/categoryVisits.php
@@ -1,0 +1,13 @@
+<?php
+require_once __DIR__ . '/../config/config.php';
+
+// Ensure we have a database connection
+if (!isset($pdo)) {
+    require __DIR__ . '/conn.php';
+}
+
+if (!empty($id)) {
+    $stmt = $pdo->prepare('UPDATE categorias SET visitas = visitas + 1 WHERE id = ?');
+    $stmt->execute([$id]);
+}
+?>


### PR DESCRIPTION
## Summary
- Increment category `visitas` counter when viewing category page
- Centralize visit counter logic in reusable script
- Expose `visitas` in categories API for downstream clients

## Testing
- `php -l routes/categorias.php src/scripts/categoryVisits.php src/api/categories/read_all_categories.php`


------
https://chatgpt.com/codex/tasks/task_b_688eaa2908c88333a02c1b22ca71ade1